### PR TITLE
Run analysis jobs on Condor split by sample and file

### DIFF
--- a/AnalysisManager.h
+++ b/AnalysisManager.h
@@ -115,7 +115,7 @@ public :
     std::vector<std::string>      ListSampleNames();
     void            PrintBDTInfoValues(BDTInfo bdt);
     
-    void            Loop(std::string sampleName="");
+    void            Loop(std::string sampleName="", std::string filename="", int fNum=1 );
     //virtual void     WriteBDTs(std::string indirname, std::string infilename, std::string outdirname, std::string outfilename, std::string cutstring);
     //Value            RetrieveValue(std::string key);
     

--- a/HelperClasses/SampleContainer.cc
+++ b/HelperClasses/SampleContainer.cc
@@ -39,7 +39,7 @@ inline SampleContainer::SampleContainer()
     doJetFlavorSplit = false;
 }
 
-inline void SampleContainer::AddFile(char* fname) {
+inline void SampleContainer::AddFile(const char* fname) {
     sampleChain->Add(fname);
     files.push_back(fname);
     std::cout<<nProFromFile<<std::endl; 

--- a/HelperClasses/SampleContainer.h
+++ b/HelperClasses/SampleContainer.h
@@ -32,7 +32,7 @@ class SampleContainer {
     bool nProFromFile;
     bool doJetFlavorSplit; // split events by jet parton flavor
     
-    void AddFile(char* fname);
+    void AddFile(const char* fname);
     void ComputeWeight(float);
 
   /** adds a lumi section range to 'goodLumis' (typically

--- a/VHbbAnalysis/RunAnalysis.py
+++ b/VHbbAnalysis/RunAnalysis.py
@@ -43,27 +43,33 @@ else:
 
     submitFiles = []
 
-    for sampleName in am.ListSampleNames():
+    #for sampleName in am.ListSampleNames(): 
+    for sample in am.samples:
+        sampleName = sample.sampleName
         print sampleName
-        fname = "%s/%s.submit" % (jobName, sampleName)
-        submitFile = open(fname, "w")
-        content =  "universe = vanilla\n"
-        content += "Executable = condor_runscript.sh\n"
-        content += "Arguments = %s %s\n" % (options.configFile, sampleName)
-        #content += "Requirements   =  OpSys == 'LINUX' && (Arch =='INTEL' || Arch =='x86_64')\n"
-        content += "initialdir = %s\n" % jobName
-        content += "Should_Transfer_Files = YES\n"
-        content += "Output = %s.stdout\n" % sampleName
-        content += "Error  = %s.stderr\n" % sampleName
-        content += "Log    = %s.log\n"    % sampleName
-        content += "Notification = never\n"
-        content += "WhenToTransferOutput=On_Exit\n"
-        content += "transfer_input_files = ../%s,../cfg/samples.txt,../cfg/earlybranches.txt,../cfg/existingbranches.txt,../cfg/newbranches.txt,../cfg/bdtsettings.txt,../cfg/reg1_settings.txt,../cfg/reg2_settings.txt,../cfg/settings.txt,../aux/new-weights-23Jan.xml,../aux/TMVA_8TeV_H125Sig_LFHFWjetsNewTTbarVVBkg_newCuts4_BDT.weights.xml,../RunSample.py,../../AnalysisDict.so\n" % options.configFile
-        content += "Queue = 1\n"
-        print content
-        submitFile.write(content)
-        submitFile.close()
-        submitFiles.append(fname)
+        os.system("mkdir -p %s/%s" % (jobName,sampleName))
+        nFiles = 0
+        for filename in sample.files:
+            nFiles += 1
+            fname = "%s/%s/%i.submit" % (jobName, sampleName,nFiles)
+            submitFile = open(fname, "w")
+            content =  "universe = vanilla\n"
+            content += "Executable = condor_runscript.sh\n"
+            content += "Arguments = %s %s %s %i\n" % (options.configFile, sampleName, filename, nFiles)
+            #content += "Requirements   =  OpSys == 'LINUX' && (Arch =='INTEL' || Arch =='x86_64')\n"
+            content += "initialdir = %s/%s\n" % (jobName,sampleName)
+            content += "Should_Transfer_Files = YES\n"
+            content += "Output = %i.stdout\n" % nFiles
+            content += "Error  = %i.stderr\n" % nFiles
+            content += "Log    = %i.log\n"    % nFiles
+            content += "Notification = never\n"
+            content += "WhenToTransferOutput=On_Exit\n"
+            content += "transfer_input_files = ../../%s,../../cfg/samples.txt,../../cfg/earlybranches.txt,../../cfg/existingbranches.txt,../../cfg/newbranches.txt,../../cfg/bdtsettings.txt,../../cfg/reg1_settings.txt,../../cfg/reg2_settings.txt,../../cfg/settings.txt,../../aux/new-weights-23Jan.xml,../../aux/TMVA_8TeV_H125Sig_LFHFWjetsNewTTbarVVBkg_newCuts4_BDT.weights.xml,../../RunSample.py,../../../AnalysisDict.so\n" % options.configFile
+            content += "Queue = 1\n"
+            print content
+            submitFile.write(content)
+            submitFile.close()
+            submitFiles.append(fname)
 
     # Send job to condor
     print "Submit files created, sending jobs to Condor..."

--- a/VHbbAnalysis/RunSample.py
+++ b/VHbbAnalysis/RunSample.py
@@ -2,8 +2,9 @@ import ROOT
 import sys
 import ReadInput
 
-if len(sys.argv) < 3:
+if (len(sys.argv) != 3 and len(sys.argv) != 5):
     print "Please give two arguments:  the cfg file and the sample name"
+    print "Or give four arguments: the cfg file, the sample name, an input file, and the input file number"
     sys.exit(0)
 
 # do stuff :)
@@ -13,10 +14,16 @@ ROOT.gSystem.Load("AnalysisDict.so")
 am=ReadInput.ReadTextFile(sys.argv[1], "cfg")
 am.debug=2
 
+print "Read in the input files, now let's run it!"
 if(am.debug>100):
     am.PrintBranches()
 
+print "Done printing branches, now to loop"
 # loop over all the samples
 # FIXME - need to add the possibility of doing a small portion of files
-#am.Loop()
-am.Loop(sys.argv[2])
+#aim.Loop()
+
+if (len(sys.argv) == 3):
+    am.Loop(sys.argv[2])
+else:
+    am.Loop(sys.argv[2], sys.argv[3], int(sys.argv[4]))

--- a/VHbbAnalysis/condor_runscript.sh
+++ b/VHbbAnalysis/condor_runscript.sh
@@ -29,6 +29,6 @@ mv new-weights-23Jan.xml TMVA_8TeV_H125Sig_LFHFWjetsNewTTbarVVBkg_newCuts4_BDT.w
 
 
 echo "running RunSample.py"
-python RunSample.py $1 $2
+python RunSample.py $1 $2 $3 $4
 ls
 echo "all done!"

--- a/plugins/VHbbAnalysis.cc
+++ b/plugins/VHbbAnalysis.cc
@@ -115,10 +115,12 @@ bool VHbbAnalysis::Analyze(){
     if(d["hJets_pt"][0] < *f["j1ptCut"] || d["hJets_pt"][1] < *f["j2ptCut"]) return false;
     */
 
-    // Cut on the bjets that we select
+    // We do this now in the jet selection methods
+    /*// Cut on the bjets that we select
     if(max(f["Jet_btagCSV"][*in["hJetInd1"]],f["Jet_btagCSV"][*in["hJetInd2"]]) < *f["j1ptCSV"] || min(f["Jet_btagCSV"][*in["hJetInd1"]],f["Jet_btagCSV"][*in["hJetInd2"]]) < *f["j2ptCSV"]) sel = false;
     if(f["Jet_pt"][*in["hJetInd1"]] < *f["j1ptCut"] || f["Jet_pt"][*in["hJetInd2"]] < *f["j2ptCut"]) sel = false; 
-    
+    */    
+
     if (sel) *in["cutFlow"] += 1; // selected jets
 
     if(debug>1000) {
@@ -1273,6 +1275,8 @@ std::pair<int,int> VHbbAnalysis::HighestPtJJBJets(){
             } 
         }      
     }
+    if (f["Jet_btagCSV"][pair.first] < *f["j1ptCSV"]) pair.first = -1;
+    if (f["Jet_btagCSV"][pair.second] < *f["j2ptCSV"]) pair.second = -1;
     return pair;    
 }
 


### PR DESCRIPTION
Hi Chris,

Now when we submit jobs we run one job on each file. We should still get the weight right as well. I tested this on the LPC and sent out test jobs on Condor, everything looks fine. Now we should be able to process the V12 campaign much faster. In fact I'm going to send out the jobs now for the full set of V12 samples, unless you see something fishy here in this code.

Cheers,
Stephane