### PR TITLE
finish initial shape systematic implementation

### DIFF
--- a/AnalysisManager.cc
+++ b/AnalysisManager.cc
@@ -665,12 +665,26 @@ void AnalysisManager::ApplySystematics(bool early){
             // smearing can be added at any time
             if(thisType==2){
                 // scale the current branch
-                *f[oldBranchName.c_str()]=*f[oldBranchName.c_str()] * cursyst->scales[iBrnch];
+                if (cursyst->scaleVar == "") {
+                    // flat scaling
+                    *f[oldBranchName.c_str()]=*f[oldBranchName.c_str()] * cursyst->scales[iBrnch];
+                }
+                else {
+                    // dynamic scaling
+                    *f[oldBranchName.c_str()]=*f[oldBranchName.c_str()] * *f[cursyst->scaleVar];
+                }
                 // copy the value to the new branch
                 *f[systBranchName.c_str()]=*f[oldBranchName.c_str()];
             } else if(thisType==3){
                 // scale the current branch
-                *d[oldBranchName.c_str()]=*d[oldBranchName.c_str()] * cursyst->scales[iBrnch];
+                if (cursyst->scaleVar == "") {
+                    // flat scaling
+                    *d[oldBranchName.c_str()]=*d[oldBranchName.c_str()] * cursyst->scales[iBrnch];
+                }
+                else {
+                    // dynamic scaling
+                    *d[oldBranchName.c_str()]=*d[oldBranchName.c_str()] * *d[cursyst->scaleVar];
+                }
                 // copy the value to the new branch
                 *d[systBranchName.c_str()]=*d[oldBranchName.c_str()];
             } else if(thisType==7){
@@ -678,7 +692,14 @@ void AnalysisManager::ApplySystematics(bool early){
                 //std::cout<<"length "<<*in[existingBranchInfo->lengthBranch]<<std::endl;
                 for(int ind=0; ind<*in[existingBranchInfo->lengthBranch]; ind++){// scale the current branch
                     //std::cout<<"old val "<<f[oldBranchName.c_str()][ind]<<std::endl;
-                    f[oldBranchName.c_str()][ind]=f[oldBranchName.c_str()][ind] * cursyst->scales[iBrnch];
+                    if (cursyst->scaleVar == "") {
+                         // flat scaling
+                         f[oldBranchName.c_str()][ind]=f[oldBranchName.c_str()][ind] * cursyst->scales[iBrnch];
+                    }
+                    else {
+                         // dynamic scaling
+                         f[oldBranchName.c_str()][ind]=f[oldBranchName.c_str()][ind] * f[cursyst->scaleVar][ind];
+                    }
                     //std::cout<<"new val "<<f[oldBranchName.c_str()][ind]<<std::endl;
                     // copy the value to the new branch
                     f[systBranchName.c_str()][ind]=f[oldBranchName.c_str()][ind];
@@ -686,7 +707,14 @@ void AnalysisManager::ApplySystematics(bool early){
                 }
             } else if(thisType==8){
                 for(int ind=0; ind<*in[existingBranchInfo->lengthBranch]; ind++){// scale the current branch
-                    d[oldBranchName.c_str()][ind]=d[oldBranchName.c_str()][ind] * cursyst->scales[iBrnch];
+                    if (cursyst->scaleVar == "") {
+                         // flat scaling
+                        d[oldBranchName.c_str()][ind]=d[oldBranchName.c_str()][ind] * cursyst->scales[iBrnch];
+                    }
+                    else {
+                        // dynamic scaling
+                        d[oldBranchName.c_str()][ind]=d[oldBranchName.c_str()][ind] * d[cursyst->scaleVar][ind];
+                    }
                     // copy the value to the new branch
                     d[systBranchName.c_str()][ind]=d[oldBranchName.c_str()][ind];
                 }

--- a/HelperClasses/SystematicContainer.cc
+++ b/HelperClasses/SystematicContainer.cc
@@ -11,6 +11,7 @@ inline SystematicContainer::SystematicContainer()
 {
     name = "";
     apply=true;
+    scaleVar = "";
 }
 
 inline void SystematicContainer::TurnOff(){

--- a/HelperClasses/SystematicContainer.h
+++ b/HelperClasses/SystematicContainer.h
@@ -22,6 +22,7 @@ class SystematicContainer {
     std::vector<std::string> branchesToEdit;
     std::vector<float> scales;  // scale value by
     std::vector<float> smears;  // smear value (after scaling)
+    std::string scaleVar; // dynamic scaling, JER's for example
 
     // anticipating tables of eta/pt
     TH2F scaleTable;

--- a/VHbbAnalysis/cfg/existingbranches.txt
+++ b/VHbbAnalysis/cfg/existingbranches.txt
@@ -98,6 +98,14 @@ type=7  name=Jet_btagnew                      max=100     lengthBranch=nJet
 type=7  name=Jet_btagCMVA                     max=100     lengthBranch=nJet
 type=6  name=Jet_mcMatchId                    max=100     lengthBranch=nJet  onlyMC=1 
 type=7  name=Jet_corr                         max=100     lengthBranch=nJet
+type=7  name=Jet_corr_JECUp                   max=100     lengthBranch=nJet
+type=7  name=Jet_corr_JECDown                 max=100     lengthBranch=nJet
+type=7  name=Jet_corr_JERUp                   max=100     lengthBranch=nJet
+type=7  name=Jet_corr_JERDown                 max=100     lengthBranch=nJet
+type=7  name=Jet_bTagWeightHFUp               max=100     lengthBranch=nJet
+type=7  name=Jet_bTagWeightHFDown             max=100     lengthBranch=nJet
+type=7  name=Jet_bTagWeightLFUp               max=100     lengthBranch=nJet
+type=7  name=Jet_bTagWeightLFDown             max=100     lengthBranch=nJet
 
 type=1  name=nGenBQuarkFromH                  onlyMC=1
 type=7  name=GenBQuarkFromH_pt        max=10  onlyMC=1

--- a/VHbbAnalysis/cfg/systematics.txt
+++ b/VHbbAnalysis/cfg/systematics.txt
@@ -1,3 +1,10 @@
 #nominal needs to go last
-name=JES_Up   branches=Jet_pt,Jet_rawPt   scales=1.1,1.1   smears=0,0
+name=JEC_Up       branches=Jet_pt,Jet_rawPt  scaleVar=Jet_corr_JECUp
+name=JEC_Down     branches=Jet_pt,Jet_rawPt  scaleVar=Jet_corr_JECDown
+name=JER_Up       branches=Jet_pt,Jet_rawPt  scaleVar=Jet_corr_JERUp
+name=JER_Down     branches=Jet_pt,Jet_rawPt  scaleVar=Jet_corr_JERDown
+name=bTagHFUp     branches=Jet_btagCSV       scaleVar=Jet_bTagWeightHFUp
+name=bTagHFDown   branches=Jet_btagCSV       scaleVar=Jet_bTagWeightHFDown
+name=bTagLFUp     branches=Jet_btagCSV       scaleVar=Jet_bTagWeightLFUp
+name=bTagLFDown   branches=Jet_btagCSV       scaleVar=Jet_bTagWeightLFDown
 name=nominal

--- a/plugins/VHbbAnalysis.cc
+++ b/plugins/VHbbAnalysis.cc
@@ -246,7 +246,12 @@ bool VHbbAnalysis::Analyze(){
     // Now we can calculate whatever we want (transverse) with W and H four-vectors
     *f["HVdPhi"] = Hbb.DeltaPhi(W);
     *f["H_mass_step2"] = *f["H_mass"];
-    *f["H_mass"] = Hbb.M(); // mass window cut? regression applied in FinishEvent
+    if (cursyst->name == "nominal") {
+        *f["H_mass"] = Hbb.M(); // mass window cut? regression applied in FinishEvent
+    }
+    else {
+        *f[Form("H_mass_%s",cursyst->name.c_str())] = Hbb.M();
+    }
     //*f["H_pt"] = Hbb.Pt(); // we already do this
 
 
@@ -722,7 +727,12 @@ void VHbbAnalysis::FinishEvent(){
                 PrintBDTInfoValues(tmpBDT);
                 std::cout<<"BDT evaluates to: "<<tmpBDT.reader->EvaluateMVA(tmpBDT.bdtmethod)<<std::endl;
             }
-            *f[tmpBDT.bdtname] = tmpBDT.reader->EvaluateMVA(tmpBDT.bdtmethod);
+            std::string bdtname(tmpBDT.bdtname);
+            if (cursyst->name != "nominal") {
+                bdtname.append("_");
+                bdtname.append(cursyst->name);
+            }
+            *f[bdtname] = tmpBDT.reader->EvaluateMVA(tmpBDT.bdtmethod);
         }
     }   
 

--- a/python/ReadInput.py
+++ b/python/ReadInput.py
@@ -169,6 +169,7 @@ def ReadTextFile(filename, filetype, samplesToRun="", fileToRun=""):
             for syst in systs:
                 print "add Systematic"
                 am.AddSystematic(syst)
+                am.SetupNewBranch("Pass_%s" % syst.name, 4)
                 print "added Systematic"
 
         return am    

--- a/python/ReadInput.py
+++ b/python/ReadInput.py
@@ -382,6 +382,8 @@ def SetupSyst(lines):
                 smears=[]
                 for smear in value.split(","):
                     syst.AddSmear(float(smear))
+            elif key=="scaleVar":
+                syst.scaleVar=value
             else:
                 print "In systematics file, what is:",item
 


### PR DESCRIPTION
I moved the fChain->GetEntry() call within the systematics loop. This way if we edit any existing branches with ApplySytematics() they will get reset to the value in the input tree before looping over the next systematic. I think this is what we wanted.

I also added a branch for each systematic, Pass_[sysName] that keeps track of whether the event passed for each systematic individually.

Finally, I added branches for Mjj and for the BDT (in general all of them if we eventually have more than one) for each systematic, since we will need these shapes for the datacards if we want to use the shape systematics.