### PR TITLE
merged fixes in HighestPtJJBJets() function + creation of HighestCMVABJets to order jets according to CMVA values

### DIFF
--- a/VHbbAnalysis/cfg/newbranches.txt
+++ b/VHbbAnalysis/cfg/newbranches.txt
@@ -7,10 +7,12 @@ type=2  name=MetTkMetDPhi
 type=1  name=nGenStatus2bHad
 type=1  name=hJetInd1
 type=1  name=hJetInd1_bestCSV
+type=1  name=hJetInd1_bestCMVA
 type=1  name=hJetInd1_highestPt
 type=1  name=hJetInd1_highestPtJJ
 type=1  name=hJetInd2
 type=1  name=hJetInd2_bestCSV
+type=1  name=hJetInd2_bestCMVA
 type=1  name=hJetInd2_highestPt
 type=1  name=hJetInd2_highestPtJJ
 type=1  name=elInd1

--- a/plugins/VHbbAnalysis.cc
+++ b/plugins/VHbbAnalysis.cc
@@ -391,6 +391,9 @@ bool VHbbAnalysis::Analyze() {
         j1ptCSV = m("j1ptCSV_2lepchan");
     }
 
+    std::pair<int,int> bjets_bestCMVA = HighestCMVABJets(j1ptCut, j2ptCut);
+    *in["hJetInd1_bestCMVA"] = bjets_bestCMVA.first;
+    *in["hJetInd2_bestCMVA"] = bjets_bestCMVA.second;
     std::pair<int,int> bjets_bestCSV = HighestCSVBJets(j1ptCut, j2ptCut);
     *in["hJetInd1_bestCSV"] = bjets_bestCSV.first;
     *in["hJetInd2_bestCSV"] = bjets_bestCSV.second;
@@ -402,7 +405,7 @@ bool VHbbAnalysis::Analyze() {
     *in["hJetInd2_highestPtJJ"] = bjets_highestPtJJ.second;
 
     // the jet selection algorithm we actually use for the rest of the analysis chain
-    std::pair<int,int> bjets = HighestCSVBJets(j1ptCut, j2ptCut);
+    std::pair<int,int> bjets = HighestCMVABJets(j1ptCut, j2ptCut);
 
     // put CMVA cuts out of selection functions
     if (bjets.first != -1 && bjets.second != -1) {
@@ -2347,6 +2350,43 @@ std::pair<int,int> VHbbAnalysis::HighestCSVBJets(float j1ptCut, float j2ptCut){
 
     // different pt threshold can set the highest CSV value into pair.second
     if (pair.first > -1 && pair.second > -1 && m("Jet_btagCSVV2",pair.first) < m("Jet_btagCSVV2",pair.second)) {
+        pair = std::make_pair(pair.second, pair.first);
+    }
+
+    return pair;
+}
+
+
+std::pair<int,int> VHbbAnalysis::HighestCMVABJets(float j1ptCut, float j2ptCut){
+    std::pair<int,int> pair(-1,-1);
+
+    for(int i=0; i<mInt("nJet"); i++){
+        if(mInt("Jet_puId",i) > 0
+            && m("Jet_bReg",i)>j1ptCut
+            &&fabs(m("Jet_eta",i))<=m("JetEtaCut")) {
+            if( pair.first == -1 ) {
+                pair.first = i;
+            } else if(m("Jet_btagCMVA",pair.first)<m("Jet_btagCMVA",i)){
+                pair.first = i;
+            }
+        }
+    }
+
+    for(int i=0; i<mInt("nJet"); i++){
+        if(i==pair.first) continue;
+        if(mInt("Jet_puId",i) > 0
+            && m("Jet_bReg",i)>j2ptCut
+            &&fabs(m("Jet_eta",i))<m("JetEtaCut")) {
+            if( pair.second == -1 ) {
+                pair.second = i;
+            } else if(m("Jet_btagCMVA",pair.second)<m("Jet_btagCMVA",i)){
+                pair.second = i;
+            }
+        }
+    }
+
+    // different pt threshold can set the highest CMVA value into pair.second
+    if (pair.first > -1 && pair.second > -1 && m("Jet_btagCMVA",pair.first) < m("Jet_btagCMVA",pair.second)) {
         pair = std::make_pair(pair.second, pair.first);
     }
 

--- a/plugins/VHbbAnalysis.cc
+++ b/plugins/VHbbAnalysis.cc
@@ -1309,8 +1309,11 @@ void VHbbAnalysis::FinishEvent() {
     if(mInt("sampleIndex")!=0){
         if (m("doICHEP") != 1) {
             *f["weight_PU"] = m("puWeight");
-            *f["weight_PUUp"] = m("puWeightUp") / m("puWeight");
-            *f["weight_PUDown"] = m("puWeightDown") / m("puWeight");
+            //TEMPORARY SOLUTION: REMEMBER TO FIX IT BACK ONCE weightUP/DOWN WILL BE IN NANOAOD
+            //  *f["weight_PUUp"] = m("puWeightUp") / m("puWeight");
+	    *f["weight_PUUp"] = m("puWeight");
+	    //  *f["weight_PUDown"] = m("puWeightDown") / m("puWeight");
+            *f["weight_PUDown"] = m("puWeight");
         }
         else {
             //*f["weight_PU"] = *f["puWeight"];
@@ -1323,7 +1326,7 @@ void VHbbAnalysis::FinishEvent() {
             // only apply to Z/W+jet samples
             *f["weight_ptQCD"]=ptWeightQCD(mInt("nGenVbosons"), m("LHE_HT"), mInt("GenVbosons_pdgId",0));
             *f["weight_ptEWK"]=ptWeightEWK(mInt("nGenVbosons"), m("GenVbosons_pt",0), m("Vtype"), mInt("GenVbosons_pdgId",0));
-        }
+	}
     } else {
         *f["weight_PU"]=1;
         *f["weight_PUUp"]=1;

--- a/plugins/VHbbAnalysis.h
+++ b/plugins/VHbbAnalysis.h
@@ -36,6 +36,7 @@ class VHbbAnalysis : public AnalysisManager {
         float puWeight_ichep_up(int i=0);
         float puWeight_ichep_down(int i=0);
         std::pair<int,int> HighestPtBJets();
+        std::pair<int,int> HighestCMVABJets(float j1ptCut, float j2ptCut);
         std::pair<int,int> HighestCSVBJets(float j1ptCut, float j2ptCut);
         std::pair<int,int> HighestPtJJBJets();
         double GetRecoTopMass(TLorentzVector Jet, bool isJet=true, int useMET=0, bool regPT=true);


### PR DESCRIPTION
Hi @scooperstein ! Here I merged an update from Chris that add the protection to the function HighestPtJJBJets. I have created another function called HighestCMVABJets that is supposed to replace HighestCSVBJets, cutting on the variable Jet_btagCMVA… however so far I kept both functions in the analyzer, just in case we would like to make some comparisons or for any reason switch back. 

I have also updated the cfg/newbranches.txt file with hJetInd1_bestCMVA and hJetInd2_bestCMVA, just in case we want save the index of the two best CMVA jets in addition to the CSV ones. At that stage code compiles and run, tested on a file in DESY [1]. 

Then a question: these modifications have also to be carried on to include Jet_btagDeepB? 

thanks, 

cheers, 

Luca

[1] /pnfs/desy.de/cms/tier2/store/user/htholen/VHbbPostNano2016_V1_mcRerun/WminusH_HToBB_WToLNu_M125_13TeV_powheg_pythia8//RunIISummer16MiniAODv2-PUMoriond17-80X-VHbbPostNano2016_V1_mcRerun/180301_122833/0000/tree_1.root